### PR TITLE
Tidy up root module

### DIFF
--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -1,9 +1,9 @@
 use digest::{FixedOutput, Input};
+use ecmult::{ECMultContext, ECMULT_CONTEXT};
 use group::{Affine, Jacobian};
 use scalar::Scalar;
 use sha2::Sha256;
-use {PublicKey, SecretKey, Error};
-use ecmult::{ ECMultContext, ECMULT_CONTEXT};
+use {Error, PublicKey, SecretKey};
 
 impl ECMultContext {
     pub fn ecdh_raw(&self, point: &Affine, scalar: &Scalar) -> Option<[u8; 32]> {

--- a/src/group.rs
+++ b/src/group.rs
@@ -4,7 +4,7 @@ use field::{Field, FieldStorage};
 /// Define an affine group element constant.
 macro_rules! affine_const {
     ($x:expr, $y:expr) => {
-        $crate::curve::Affine {
+        $crate::group::Affine {
             x: $x,
             y: $y,
             infinity: false,
@@ -29,7 +29,7 @@ macro_rules! jacobian_const {
 /// Define an affine group storage constant.
 macro_rules! affine_storage_const {
     ($x:expr, $y:expr) => {
-        $crate::curve::AffineStorage { x: $x, y: $y }
+        $crate::group::AffineStorage { x: $x, y: $y }
     };
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,11 +1,11 @@
-use group::{Affine, Jacobian};
+use core::ops::{Add, Mul, Neg};
+use ecmult::ECMULT_CONTEXT;
 use ecmult::ECMULT_GEN_CONTEXT;
+use field::Field;
+use group::{Affine, Jacobian};
+use rand::Rng;
 use scalar::Scalar;
 use Error;
-use field::Field;
-use core::ops::{Add,Mul,Neg};
-use rand::Rng;
-use ecmult::ECMULT_CONTEXT;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Public key on a secp256k1 curve.
@@ -16,7 +16,6 @@ pub struct PublicKey(pub(crate) Affine);
 pub struct SecretKey(pub(crate) Scalar);
 
 impl PublicKey {
-
     pub fn from_secret_key(seckey: &SecretKey) -> PublicKey {
         let mut pj = Jacobian::default();
         ECMULT_GEN_CONTEXT.ecmult_gen(&mut pj, &seckey.0);
@@ -65,9 +64,9 @@ impl PublicKey {
         elem.set_xy(&x, &y);
         if (p[0] == TAG_PUBKEY_HYBRID_EVEN || p[0] == TAG_PUBKEY_HYBRID_ODD)
             && (y.is_odd() != (p[0] == TAG_PUBKEY_HYBRID_ODD))
-            {
-                return Err(Error::InvalidPublicKey);
-            }
+        {
+            return Err(Error::InvalidPublicKey);
+        }
         if elem.is_infinity() {
             return Err(Error::InvalidPublicKey);
         }
@@ -128,7 +127,7 @@ impl Add for PublicKey {
     fn add(self, rhs: PublicKey) -> <Self as Add<PublicKey>>::Output {
         let mut j1 = Jacobian::default();
         j1.set_ge(&self.0);
-        let j2 = j1.add_ge( &rhs.0);
+        let j2 = j1.add_ge(&rhs.0);
         let mut ret = Affine::default();
         ret.set_gej(&j2);
         PublicKey(ret)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,205 @@
+use group::{Affine, Jacobian};
+use ecmult::ECMULT_GEN_CONTEXT;
+use scalar::Scalar;
+use Error;
+use field::Field;
+use core::ops::{Add,Mul,Neg};
+use rand::Rng;
+use ecmult::ECMULT_CONTEXT;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// Public key on a secp256k1 curve.
+pub struct PublicKey(pub(crate) Affine);
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// Secret key (256-bit) on a secp256k1 curve.
+pub struct SecretKey(pub(crate) Scalar);
+
+impl PublicKey {
+
+    pub fn from_secret_key(seckey: &SecretKey) -> PublicKey {
+        let mut pj = Jacobian::default();
+        ECMULT_GEN_CONTEXT.ecmult_gen(&mut pj, &seckey.0);
+        let mut p = Affine::default();
+        p.set_gej(&pj);
+        PublicKey(p)
+    }
+
+    pub fn parse_compressed(p: &[u8; 33]) -> Result<PublicKey, Error> {
+        if !(p[0] == 0x02 || p[0] == 0x03) {
+            return Err(Error::InvalidPublicKey);
+        }
+        let mut x = Field::default();
+        if !x.set_b32(array_ref!(p, 1, 32)) {
+            return Err(Error::InvalidPublicKey);
+        }
+        let mut elem = Affine::default();
+        if !elem.set_xo_var(&x, p[0] == 0x03) {
+            return Err(Error::InvalidPublicKey);
+        }
+        if elem.is_infinity() {
+            return Err(Error::InvalidPublicKey);
+        }
+        if elem.is_valid_var() {
+            return Ok(PublicKey(elem));
+        } else {
+            return Err(Error::InvalidPublicKey);
+        }
+    }
+
+    pub fn parse(p: &[u8; 65]) -> Result<PublicKey, Error> {
+        use util::{TAG_PUBKEY_HYBRID_EVEN, TAG_PUBKEY_HYBRID_ODD};
+
+        if !(p[0] == 0x04 || p[0] == 0x06 || p[0] == 0x07) {
+            return Err(Error::InvalidPublicKey);
+        }
+        let mut x = Field::default();
+        let mut y = Field::default();
+        if !x.set_b32(array_ref!(p, 1, 32)) {
+            return Err(Error::InvalidPublicKey);
+        }
+        if !y.set_b32(array_ref!(p, 33, 32)) {
+            return Err(Error::InvalidPublicKey);
+        }
+        let mut elem = Affine::default();
+        elem.set_xy(&x, &y);
+        if (p[0] == TAG_PUBKEY_HYBRID_EVEN || p[0] == TAG_PUBKEY_HYBRID_ODD)
+            && (y.is_odd() != (p[0] == TAG_PUBKEY_HYBRID_ODD))
+            {
+                return Err(Error::InvalidPublicKey);
+            }
+        if elem.is_infinity() {
+            return Err(Error::InvalidPublicKey);
+        }
+        if elem.is_valid_var() {
+            return Ok(PublicKey(elem));
+        } else {
+            return Err(Error::InvalidPublicKey);
+        }
+    }
+
+    pub fn serialize(&self) -> [u8; 65] {
+        use util::TAG_PUBKEY_UNCOMPRESSED;
+
+        debug_assert!(!self.0.is_infinity());
+
+        let mut ret = [0u8; 65];
+        let mut elem = self.0.clone();
+
+        elem.x.normalize_var();
+        elem.y.normalize_var();
+        elem.x.fill_b32(array_mut_ref!(ret, 1, 32));
+        elem.y.fill_b32(array_mut_ref!(ret, 33, 32));
+        ret[0] = TAG_PUBKEY_UNCOMPRESSED;
+
+        ret
+    }
+
+    pub fn serialize_compressed(&self) -> [u8; 33] {
+        use util::{TAG_PUBKEY_EVEN, TAG_PUBKEY_ODD};
+
+        debug_assert!(!self.0.is_infinity());
+
+        let mut ret = [0u8; 33];
+        let mut elem = self.0.clone();
+
+        elem.x.normalize_var();
+        elem.y.normalize_var();
+        elem.x.fill_b32(array_mut_ref!(ret, 1, 32));
+        ret[0] = if elem.y.is_odd() {
+            TAG_PUBKEY_ODD
+        } else {
+            TAG_PUBKEY_EVEN
+        };
+
+        ret
+    }
+}
+
+impl Into<Affine> for PublicKey {
+    fn into(self) -> Affine {
+        self.0
+    }
+}
+
+impl Add for PublicKey {
+    type Output = PublicKey;
+
+    fn add(self, rhs: PublicKey) -> <Self as Add<PublicKey>>::Output {
+        let mut j1 = Jacobian::default();
+        j1.set_ge(&self.0);
+        let j2 = j1.add_ge( &rhs.0);
+        let mut ret = Affine::default();
+        ret.set_gej(&j2);
+        PublicKey(ret)
+    }
+}
+
+impl SecretKey {
+    pub fn parse(p: &[u8; 32]) -> Result<SecretKey, Error> {
+        let mut elem = Scalar::default();
+        if !elem.set_b32(p) && !elem.is_zero() {
+            Ok(SecretKey(elem))
+        } else {
+            Err(Error::InvalidSecretKey)
+        }
+    }
+
+    pub fn random<R: Rng>(rng: &mut R) -> SecretKey {
+        loop {
+            let mut ret = [0u8; 32];
+            rng.fill_bytes(&mut ret);
+
+            match Self::parse(&ret) {
+                Ok(key) => return key,
+                Err(_) => (),
+            }
+        }
+    }
+
+    pub fn serialize(&self) -> [u8; 32] {
+        self.0.b32()
+    }
+}
+
+impl Into<Scalar> for SecretKey {
+    fn into(self) -> Scalar {
+        self.0
+    }
+}
+
+impl Add for SecretKey {
+    type Output = SecretKey;
+
+    fn add(self, rhs: SecretKey) -> <Self as Add<SecretKey>>::Output {
+        SecretKey(self.0 + rhs.0)
+    }
+}
+
+impl Mul<SecretKey> for SecretKey {
+    type Output = SecretKey;
+
+    fn mul(self, rhs: SecretKey) -> SecretKey {
+        SecretKey(self.0 * rhs.0)
+    }
+}
+
+impl Mul<PublicKey> for SecretKey {
+    type Output = PublicKey;
+
+    fn mul(self, rhs: PublicKey) -> PublicKey {
+        let mut pj = Jacobian::default();
+        ECMULT_CONTEXT.ecmult_const(&mut pj, &rhs.0, &self.0);
+        let mut p = Affine::default();
+        p.set_gej(&pj);
+        PublicKey(p)
+    }
+}
+
+impl Neg for SecretKey {
+    type Output = SecretKey;
+
+    fn neg(self) -> <Self as Neg>::Output {
+        SecretKey(-self.0)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,9 @@ pub mod keys;
 pub mod signature;
 pub mod util;
 
-pub use keys::{SecretKey, PublicKey};
-pub use signature::{ Signature, verify, recover};
 pub use ecdh::SharedSecret;
-
+pub use keys::{PublicKey, SecretKey};
+pub use signature::{recover, verify, Signature};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Tag used for public key recovery from signatures.
@@ -41,7 +40,6 @@ pub struct RecoveryId(u8);
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Hashed message input to an ECDSA signature.
 pub struct Message(pub Scalar);
-
 
 impl Message {
     pub fn parse(p: &[u8; 32]) -> Message {
@@ -81,6 +79,3 @@ impl Into<i32> for RecoveryId {
         self.0 as i32
     }
 }
-
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,19 +19,16 @@ mod ecdh;
 mod ecdsa;
 pub mod ecmult;
 mod error;
-mod scalar;
-
-pub use error::Error;
-
 mod keys;
+mod message;
 mod recovery_id;
+mod scalar;
 pub mod signature;
 pub mod util;
-mod message;
 
 pub use ecdh::SharedSecret;
+pub use error::Error;
 pub use keys::{PublicKey, SecretKey};
-pub use signature::{recover, verify, Signature};
 pub use message::Message;
 pub use recovery_id::RecoveryId;
-
+pub use signature::Signature;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,38 +21,21 @@ pub mod ecmult;
 mod error;
 mod scalar;
 
-use scalar::Scalar;
-
 pub use error::Error;
 
-pub mod keys;
+mod keys;
 pub mod signature;
 pub mod util;
+pub mod message;
 
 pub use ecdh::SharedSecret;
 pub use keys::{PublicKey, SecretKey};
 pub use signature::{recover, verify, Signature};
+pub use message::Message;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Tag used for public key recovery from signatures.
 pub struct RecoveryId(u8);
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-/// Hashed message input to an ECDSA signature.
-pub struct Message(pub Scalar);
-
-impl Message {
-    pub fn parse(p: &[u8; 32]) -> Message {
-        let mut m = Scalar::default();
-        m.set_b32(p);
-
-        Message(m)
-    }
-
-    pub fn serialize(&self) -> [u8; 32] {
-        self.0.b32()
-    }
-}
 
 impl RecoveryId {
     pub fn parse(p: u8) -> Result<RecoveryId, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,18 +25,14 @@ use hmac_drbg::HmacDRBG;
 use sha2::Sha256;
 use typenum::U32;
 
-use field::Field;
-use group::{Affine, Jacobian};
 use scalar::Scalar;
 
 use ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
 
-use rand::Rng;
-
-use core::ops::Add;
-use core::ops::Mul;
-use core::ops::Neg;
 pub use error::Error;
+
+pub mod keys;
+pub use keys::{SecretKey, PublicKey};
 
 /// Curve related structs.
 pub mod curve {
@@ -61,14 +57,6 @@ pub mod util {
     pub use group::{globalz_set_table_gej, set_table_gej_var, AFFINE_INFINITY, JACOBIAN_INFINITY};
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-/// Public key on a secp256k1 curve.
-pub struct PublicKey(Affine);
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-/// Secret key (256-bit) on a secp256k1 curve.
-pub struct SecretKey(Scalar);
-
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// An ECDSA signature.
 pub struct Signature {
@@ -87,195 +75,6 @@ pub struct Message(pub Scalar);
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Shared secret using ECDH.
 pub struct SharedSecret([u8; 32]);
-
-impl PublicKey {
-
-    pub fn from_secret_key(seckey: &SecretKey) -> PublicKey {
-        let mut pj = Jacobian::default();
-        ECMULT_GEN_CONTEXT.ecmult_gen(&mut pj, &seckey.0);
-        let mut p = Affine::default();
-        p.set_gej(&pj);
-        PublicKey(p)
-    }
-
-    pub fn parse_compressed(p: &[u8; 33]) -> Result<PublicKey, Error> {
-        if !(p[0] == 0x02 || p[0] == 0x03) {
-            return Err(Error::InvalidPublicKey);
-        }
-        let mut x = Field::default();
-        if !x.set_b32(array_ref!(p, 1, 32)) {
-            return Err(Error::InvalidPublicKey);
-        }
-        let mut elem = Affine::default();
-        if !elem.set_xo_var(&x, p[0] == 0x03) {
-            return Err(Error::InvalidPublicKey);
-        }
-        if elem.is_infinity() {
-            return Err(Error::InvalidPublicKey);
-        }
-        if elem.is_valid_var() {
-            return Ok(PublicKey(elem));
-        } else {
-            return Err(Error::InvalidPublicKey);
-        }
-    }
-
-    pub fn parse(p: &[u8; 65]) -> Result<PublicKey, Error> {
-        use util::{TAG_PUBKEY_HYBRID_EVEN, TAG_PUBKEY_HYBRID_ODD};
-
-        if !(p[0] == 0x04 || p[0] == 0x06 || p[0] == 0x07) {
-            return Err(Error::InvalidPublicKey);
-        }
-        let mut x = Field::default();
-        let mut y = Field::default();
-        if !x.set_b32(array_ref!(p, 1, 32)) {
-            return Err(Error::InvalidPublicKey);
-        }
-        if !y.set_b32(array_ref!(p, 33, 32)) {
-            return Err(Error::InvalidPublicKey);
-        }
-        let mut elem = Affine::default();
-        elem.set_xy(&x, &y);
-        if (p[0] == TAG_PUBKEY_HYBRID_EVEN || p[0] == TAG_PUBKEY_HYBRID_ODD)
-            && (y.is_odd() != (p[0] == TAG_PUBKEY_HYBRID_ODD))
-            {
-                return Err(Error::InvalidPublicKey);
-            }
-        if elem.is_infinity() {
-            return Err(Error::InvalidPublicKey);
-        }
-        if elem.is_valid_var() {
-            return Ok(PublicKey(elem));
-        } else {
-            return Err(Error::InvalidPublicKey);
-        }
-    }
-
-    pub fn serialize(&self) -> [u8; 65] {
-        use util::TAG_PUBKEY_UNCOMPRESSED;
-
-        debug_assert!(!self.0.is_infinity());
-
-        let mut ret = [0u8; 65];
-        let mut elem = self.0.clone();
-
-        elem.x.normalize_var();
-        elem.y.normalize_var();
-        elem.x.fill_b32(array_mut_ref!(ret, 1, 32));
-        elem.y.fill_b32(array_mut_ref!(ret, 33, 32));
-        ret[0] = TAG_PUBKEY_UNCOMPRESSED;
-
-        ret
-    }
-
-    pub fn serialize_compressed(&self) -> [u8; 33] {
-        use util::{TAG_PUBKEY_EVEN, TAG_PUBKEY_ODD};
-
-        debug_assert!(!self.0.is_infinity());
-
-        let mut ret = [0u8; 33];
-        let mut elem = self.0.clone();
-
-        elem.x.normalize_var();
-        elem.y.normalize_var();
-        elem.x.fill_b32(array_mut_ref!(ret, 1, 32));
-        ret[0] = if elem.y.is_odd() {
-            TAG_PUBKEY_ODD
-        } else {
-            TAG_PUBKEY_EVEN
-        };
-
-        ret
-    }
-}
-
-impl Into<Affine> for PublicKey {
-    fn into(self) -> Affine {
-        self.0
-    }
-}
-
-impl Add for PublicKey {
-    type Output = PublicKey;
-
-    fn add(self, rhs: PublicKey) -> <Self as Add<PublicKey>>::Output {
-        let mut j1 = Jacobian::default();
-        j1.set_ge(&self.0);
-        let j2 = j1.add_ge( &rhs.0);
-        let mut ret = Affine::default();
-        ret.set_gej(&j2);
-        PublicKey(ret)
-    }
-}
-
-impl SecretKey {
-    pub fn parse(p: &[u8; 32]) -> Result<SecretKey, Error> {
-        let mut elem = Scalar::default();
-        if !elem.set_b32(p) && !elem.is_zero() {
-            Ok(SecretKey(elem))
-        } else {
-            Err(Error::InvalidSecretKey)
-        }
-    }
-
-    pub fn random<R: Rng>(rng: &mut R) -> SecretKey {
-        loop {
-            let mut ret = [0u8; 32];
-            rng.fill_bytes(&mut ret);
-
-            match Self::parse(&ret) {
-                Ok(key) => return key,
-                Err(_) => (),
-            }
-        }
-    }
-
-    pub fn serialize(&self) -> [u8; 32] {
-        self.0.b32()
-    }
-}
-
-impl Into<Scalar> for SecretKey {
-    fn into(self) -> Scalar {
-        self.0
-    }
-}
-
-impl Add for SecretKey {
-    type Output = SecretKey;
-
-    fn add(self, rhs: SecretKey) -> <Self as Add<SecretKey>>::Output {
-        SecretKey(self.0 + rhs.0)
-    }
-}
-
-impl Mul<SecretKey> for SecretKey {
-    type Output = SecretKey;
-
-    fn mul(self, rhs: SecretKey) -> SecretKey {
-        SecretKey(self.0 * rhs.0)
-    }
-}
-
-impl Mul<PublicKey> for SecretKey {
-    type Output = PublicKey;
-
-    fn mul(self, rhs: PublicKey) -> PublicKey {
-        let mut pj = Jacobian::default();
-        ECMULT_CONTEXT.ecmult_const(&mut pj, &rhs.0, &self.0);
-        let mut p = Affine::default();
-        p.set_gej(&pj);
-        PublicKey(p)
-    }
-}
-
-impl Neg for SecretKey {
-    type Output = SecretKey;
-
-    fn neg(self) -> <Self as Neg>::Output {
-        SecretKey(-self.0)
-    }
-}
 
 impl Signature {
     pub fn parse(p: &[u8; 64]) -> Signature {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,41 +24,14 @@ mod scalar;
 pub use error::Error;
 
 mod keys;
+mod recovery_id;
 pub mod signature;
 pub mod util;
-pub mod message;
+mod message;
 
 pub use ecdh::SharedSecret;
 pub use keys::{PublicKey, SecretKey};
 pub use signature::{recover, verify, Signature};
 pub use message::Message;
+pub use recovery_id::RecoveryId;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-/// Tag used for public key recovery from signatures.
-pub struct RecoveryId(u8);
-
-impl RecoveryId {
-    pub fn parse(p: u8) -> Result<RecoveryId, Error> {
-        if p < 4 {
-            Ok(RecoveryId(p))
-        } else {
-            Err(Error::InvalidRecoveryId)
-        }
-    }
-
-    pub fn serialize(&self) -> u8 {
-        self.0
-    }
-}
-
-impl Into<u8> for RecoveryId {
-    fn into(self) -> u8 {
-        self.0
-    }
-}
-
-impl Into<i32> for RecoveryId {
-    fn into(self) -> i32 {
-        self.0 as i32
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,19 +43,7 @@ pub mod curve {
     pub use ecmult::{ECMultContext, ECMultGenContext, ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
 }
 
-/// Utilities to manipulate the secp256k1 curve parameters.
-pub mod util {
-    pub const TAG_PUBKEY_EVEN: u8 = 0x02;
-    pub const TAG_PUBKEY_ODD: u8 = 0x03;
-    pub const TAG_PUBKEY_UNCOMPRESSED: u8 = 0x04;
-    pub const TAG_PUBKEY_HYBRID_EVEN: u8 = 0x06;
-    pub const TAG_PUBKEY_HYBRID_ODD: u8 = 0x07;
-
-    pub use ecmult::{
-        odd_multiples_table, ECMULT_TABLE_SIZE_A, ECMULT_TABLE_SIZE_G, WINDOW_A, WINDOW_G,
-    };
-    pub use group::{globalz_set_table_gej, set_table_gej_var, AFFINE_INFINITY, JACOBIAN_INFINITY};
-}
+pub mod util;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// An ECDSA signature.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,40 +17,22 @@ mod field;
 mod group;
 mod ecdh;
 mod ecdsa;
-mod ecmult;
+pub mod ecmult;
 mod error;
 mod scalar;
 
-use hmac_drbg::HmacDRBG;
-use sha2::Sha256;
-use typenum::U32;
-
 use scalar::Scalar;
-
-use ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
 
 pub use error::Error;
 
 pub mod keys;
-pub use keys::{SecretKey, PublicKey};
-
-/// Curve related structs.
-pub mod curve {
-    pub use field::Field;
-    pub use group::{Affine, AffineStorage, Jacobian, AFFINE_G, CURVE_B};
-    pub use scalar::Scalar;
-
-    pub use ecmult::{ECMultContext, ECMultGenContext, ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
-}
-
+pub mod signature;
 pub mod util;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-/// An ECDSA signature.
-pub struct Signature {
-    pub r: Scalar,
-    pub s: Scalar,
-}
+pub use keys::{SecretKey, PublicKey};
+pub use signature::{ Signature, verify, recover};
+pub use ecdh::SharedSecret;
+
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 /// Tag used for public key recovery from signatures.
@@ -60,28 +42,6 @@ pub struct RecoveryId(u8);
 /// Hashed message input to an ECDSA signature.
 pub struct Message(pub Scalar);
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-/// Shared secret using ECDH.
-pub struct SharedSecret([u8; 32]);
-
-impl Signature {
-    pub fn parse(p: &[u8; 64]) -> Signature {
-        let mut r = Scalar::default();
-        let mut s = Scalar::default();
-
-        r.set_b32(array_ref!(p, 0, 32));
-        s.set_b32(array_ref!(p, 32, 32));
-
-        Signature { r, s }
-    }
-
-    pub fn serialize(&self) -> [u8; 64] {
-        let mut ret = [0u8; 64];
-        self.r.fill_b32(array_mut_ref!(ret, 0, 32));
-        self.s.fill_b32(array_mut_ref!(ret, 32, 32));
-        ret
-    }
-}
 
 impl Message {
     pub fn parse(p: &[u8; 32]) -> Message {
@@ -122,62 +82,5 @@ impl Into<i32> for RecoveryId {
     }
 }
 
-impl SharedSecret {
-    pub fn new(pubkey: &PublicKey, seckey: &SecretKey) -> Result<SharedSecret, Error> {
-        let inner = match ECMULT_CONTEXT.ecdh_raw(&pubkey.0, &seckey.0) {
-            Some(val) => val,
-            None => return Err(Error::InvalidSecretKey),
-        };
 
-        Ok(SharedSecret(inner))
-    }
-}
 
-impl AsRef<[u8]> for SharedSecret {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-/// Check signature is a valid message signed by public key.
-pub fn verify(message: &Message, signature: &Signature, pubkey: &PublicKey) -> bool {
-    ECMULT_CONTEXT.verify_raw(&signature.r, &signature.s, &pubkey.0, &message.0)
-}
-
-/// Recover public key from a signed message.
-pub fn recover(
-    message: &Message,
-    signature: &Signature,
-    recovery_id: &RecoveryId,
-) -> Result<PublicKey, Error> {
-    ECMULT_CONTEXT
-        .recover_raw(&signature.r, &signature.s, recovery_id.0, &message.0)
-        .map(|v| PublicKey(v))
-}
-
-/// Sign a message using the secret key.
-pub fn sign(message: &Message, seckey: &SecretKey) -> Result<(Signature, RecoveryId), Error> {
-    let seckey_b32 = seckey.0.b32();
-    let message_b32 = message.0.b32();
-
-    let mut drbg = HmacDRBG::<Sha256>::new(&seckey_b32, &message_b32, &[]);
-    let generated = drbg.generate::<U32>(None);
-    let mut nonce = Scalar::default();
-    let mut overflow = nonce.set_b32(array_ref!(generated, 0, 32));
-
-    while overflow || nonce.is_zero() {
-        let generated = drbg.generate::<U32>(None);
-        overflow = nonce.set_b32(array_ref!(generated, 0, 32));
-    }
-
-    let result = ECMULT_GEN_CONTEXT.sign_raw(&seckey.0, &message.0, &nonce);
-    #[allow(unused_assignments)]
-        {
-            nonce = Scalar::default();
-        }
-    if let Ok((sigr, sigs, recid)) = result {
-        return Ok((Signature { r: sigr, s: sigs }, RecoveryId(recid)));
-    } else {
-        return Err(result.err().unwrap());
-    }
-}

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,9 @@
+use ecmult::ECMULT_GEN_CONTEXT;
+use hmac_drbg::HmacDRBG;
 use scalar::Scalar;
+use sha2::Sha256;
+use typenum::U32;
+use {Error, RecoveryId, SecretKey, Signature};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// Hashed message input to an ECDSA signature.
@@ -14,5 +19,32 @@ impl Message {
 
     pub fn serialize(&self) -> [u8; 32] {
         self.0.b32()
+    }
+
+    /// Sign a message using the secret key.
+    pub fn sign(message: &Message, seckey: &SecretKey) -> Result<(Signature, RecoveryId), Error> {
+        let seckey_b32 = seckey.0.b32();
+        let message_b32 = message.0.b32();
+
+        let mut drbg = HmacDRBG::<Sha256>::new(&seckey_b32, &message_b32, &[]);
+        let generated = drbg.generate::<U32>(None);
+        let mut nonce = Scalar::default();
+        let mut overflow = nonce.set_b32(array_ref!(generated, 0, 32));
+
+        while overflow || nonce.is_zero() {
+            let generated = drbg.generate::<U32>(None);
+            overflow = nonce.set_b32(array_ref!(generated, 0, 32));
+        }
+
+        let result = ECMULT_GEN_CONTEXT.sign_raw(&seckey.0, &message.0, &nonce);
+        #[allow(unused_assignments)]
+        {
+            nonce = Scalar::default();
+        }
+        if let Ok((sigr, sigs, recid)) = result {
+            return Ok((Signature { r: sigr, s: sigs }, RecoveryId(recid)));
+        } else {
+            return Err(result.err().unwrap());
+        }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,18 @@
+use scalar::Scalar;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// Hashed message input to an ECDSA signature.
+pub struct Message(pub Scalar);
+
+impl Message {
+    pub fn parse(p: &[u8; 32]) -> Message {
+        let mut m = Scalar::default();
+        m.set_b32(p);
+
+        Message(m)
+    }
+
+    pub fn serialize(&self) -> [u8; 32] {
+        self.0.b32()
+    }
+}

--- a/src/recovery_id.rs
+++ b/src/recovery_id.rs
@@ -1,0 +1,31 @@
+use Error;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// Tag used for public key recovery from signatures.
+pub struct RecoveryId(pub u8);
+
+impl RecoveryId {
+    pub fn parse(p: u8) -> Result<RecoveryId, Error> {
+        if p < 4 {
+            Ok(RecoveryId(p))
+        } else {
+            Err(Error::InvalidRecoveryId)
+        }
+    }
+
+    pub fn serialize(&self) -> u8 {
+        self.0
+    }
+}
+
+impl Into<u8> for RecoveryId {
+    fn into(self) -> u8 {
+        self.0
+    }
+}
+
+impl Into<i32> for RecoveryId {
+    fn into(self) -> i32 {
+        self.0 as i32
+    }
+}

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,9 +1,9 @@
-use scalar::Scalar;
-use { Message, PublicKey, SecretKey, RecoveryId, Error};
+use ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
 use hmac_drbg::HmacDRBG;
-use typenum::U32;
+use scalar::Scalar;
 use sha2::Sha256;
-use ecmult::{ ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
+use typenum::U32;
+use {Error, Message, PublicKey, RecoveryId, SecretKey};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// An ECDSA signature.
@@ -64,9 +64,9 @@ pub fn sign(message: &Message, seckey: &SecretKey) -> Result<(Signature, Recover
 
     let result = ECMULT_GEN_CONTEXT.sign_raw(&seckey.0, &message.0, &nonce);
     #[allow(unused_assignments)]
-        {
-            nonce = Scalar::default();
-        }
+    {
+        nonce = Scalar::default();
+    }
     if let Ok((sigr, sigs, recid)) = result {
         return Ok((Signature { r: sigr, s: sigs }, RecoveryId(recid)));
     } else {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,9 +1,6 @@
-use ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
-use hmac_drbg::HmacDRBG;
+use ecmult::ECMULT_CONTEXT;
 use scalar::Scalar;
-use sha2::Sha256;
-use typenum::U32;
-use {Error, Message, PublicKey, RecoveryId, SecretKey};
+use {Error, Message, PublicKey, RecoveryId};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 /// An ECDSA signature.
@@ -29,47 +26,20 @@ impl Signature {
         self.s.fill_b32(array_mut_ref!(ret, 32, 32));
         ret
     }
-}
 
-/// Check signature is a valid message signed by public key.
-pub fn verify(message: &Message, signature: &Signature, pubkey: &PublicKey) -> bool {
-    ECMULT_CONTEXT.verify_raw(&signature.r, &signature.s, &pubkey.0, &message.0)
-}
-
-/// Recover public key from a signed message.
-pub fn recover(
-    message: &Message,
-    signature: &Signature,
-    recovery_id: &RecoveryId,
-) -> Result<PublicKey, Error> {
-    ECMULT_CONTEXT
-        .recover_raw(&signature.r, &signature.s, recovery_id.0, &message.0)
-        .map(|v| PublicKey(v))
-}
-
-/// Sign a message using the secret key.
-pub fn sign(message: &Message, seckey: &SecretKey) -> Result<(Signature, RecoveryId), Error> {
-    let seckey_b32 = seckey.0.b32();
-    let message_b32 = message.0.b32();
-
-    let mut drbg = HmacDRBG::<Sha256>::new(&seckey_b32, &message_b32, &[]);
-    let generated = drbg.generate::<U32>(None);
-    let mut nonce = Scalar::default();
-    let mut overflow = nonce.set_b32(array_ref!(generated, 0, 32));
-
-    while overflow || nonce.is_zero() {
-        let generated = drbg.generate::<U32>(None);
-        overflow = nonce.set_b32(array_ref!(generated, 0, 32));
+    /// Check signature is a valid message signed by public key.
+    pub fn verify(message: &Message, signature: &Signature, pubkey: &PublicKey) -> bool {
+        ECMULT_CONTEXT.verify_raw(&signature.r, &signature.s, &pubkey.0, &message.0)
     }
 
-    let result = ECMULT_GEN_CONTEXT.sign_raw(&seckey.0, &message.0, &nonce);
-    #[allow(unused_assignments)]
-    {
-        nonce = Scalar::default();
-    }
-    if let Ok((sigr, sigs, recid)) = result {
-        return Ok((Signature { r: sigr, s: sigs }, RecoveryId(recid)));
-    } else {
-        return Err(result.err().unwrap());
+    /// Recover public key from a signed message.
+    pub fn recover(
+        message: &Message,
+        signature: &Signature,
+        recovery_id: &RecoveryId,
+    ) -> Result<PublicKey, Error> {
+        ECMULT_CONTEXT
+            .recover_raw(&signature.r, &signature.s, recovery_id.0, &message.0)
+            .map(|v| PublicKey(v))
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,75 @@
+use scalar::Scalar;
+use { Message, PublicKey, SecretKey, RecoveryId, Error};
+use hmac_drbg::HmacDRBG;
+use typenum::U32;
+use sha2::Sha256;
+use ecmult::{ ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+/// An ECDSA signature.
+pub struct Signature {
+    pub r: Scalar,
+    pub s: Scalar,
+}
+
+impl Signature {
+    pub fn parse(p: &[u8; 64]) -> Signature {
+        let mut r = Scalar::default();
+        let mut s = Scalar::default();
+
+        r.set_b32(array_ref!(p, 0, 32));
+        s.set_b32(array_ref!(p, 32, 32));
+
+        Signature { r, s }
+    }
+
+    pub fn serialize(&self) -> [u8; 64] {
+        let mut ret = [0u8; 64];
+        self.r.fill_b32(array_mut_ref!(ret, 0, 32));
+        self.s.fill_b32(array_mut_ref!(ret, 32, 32));
+        ret
+    }
+}
+
+/// Check signature is a valid message signed by public key.
+pub fn verify(message: &Message, signature: &Signature, pubkey: &PublicKey) -> bool {
+    ECMULT_CONTEXT.verify_raw(&signature.r, &signature.s, &pubkey.0, &message.0)
+}
+
+/// Recover public key from a signed message.
+pub fn recover(
+    message: &Message,
+    signature: &Signature,
+    recovery_id: &RecoveryId,
+) -> Result<PublicKey, Error> {
+    ECMULT_CONTEXT
+        .recover_raw(&signature.r, &signature.s, recovery_id.0, &message.0)
+        .map(|v| PublicKey(v))
+}
+
+/// Sign a message using the secret key.
+pub fn sign(message: &Message, seckey: &SecretKey) -> Result<(Signature, RecoveryId), Error> {
+    let seckey_b32 = seckey.0.b32();
+    let message_b32 = message.0.b32();
+
+    let mut drbg = HmacDRBG::<Sha256>::new(&seckey_b32, &message_b32, &[]);
+    let generated = drbg.generate::<U32>(None);
+    let mut nonce = Scalar::default();
+    let mut overflow = nonce.set_b32(array_ref!(generated, 0, 32));
+
+    while overflow || nonce.is_zero() {
+        let generated = drbg.generate::<U32>(None);
+        overflow = nonce.set_b32(array_ref!(generated, 0, 32));
+    }
+
+    let result = ECMULT_GEN_CONTEXT.sign_raw(&seckey.0, &message.0, &nonce);
+    #[allow(unused_assignments)]
+        {
+            nonce = Scalar::default();
+        }
+    if let Ok((sigr, sigs, recid)) = result {
+        return Ok((Signature { r: sigr, s: sigs }, RecoveryId(recid)));
+    } else {
+        return Err(result.err().unwrap());
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,11 @@
+//! Utilities to manipulate the secp256k1 curve parameters.
+pub const TAG_PUBKEY_EVEN: u8 = 0x02;
+pub const TAG_PUBKEY_ODD: u8 = 0x03;
+pub const TAG_PUBKEY_UNCOMPRESSED: u8 = 0x04;
+pub const TAG_PUBKEY_HYBRID_EVEN: u8 = 0x06;
+pub const TAG_PUBKEY_HYBRID_ODD: u8 = 0x07;
+
+pub use ecmult::{
+    odd_multiples_table, ECMULT_TABLE_SIZE_A, ECMULT_TABLE_SIZE_G, WINDOW_A, WINDOW_G,
+};
+pub use group::{globalz_set_table_gej, set_table_gej_var, AFFINE_INFINITY, JACOBIAN_INFINITY};

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -7,7 +7,6 @@ extern crate arrayref;
 use rand::thread_rng;
 use secp256k1::{PublicKey, SecretKey};
 use secp256k1::Error;
-use secp256k1::curve::{Jacobian, Affine};
 
 #[test]
 fn create_secret() {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,12 +1,12 @@
+extern crate hex;
 extern crate rand;
 extern crate secp256k1;
-extern crate hex;
 #[macro_use]
 extern crate arrayref;
 
 use rand::thread_rng;
-use secp256k1::{PublicKey, SecretKey};
 use secp256k1::Error;
+use secp256k1::{PublicKey, SecretKey};
 
 #[test]
 fn create_secret() {
@@ -67,20 +67,23 @@ fn valid_keys() {
     let key = from_hex("0384526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07");
     assert!(key.is_ok());
     let key = from_hex("");
-    assert_eq!(key.err().unwrap(),Error::InvalidPublicKey);
+    assert_eq!(key.err().unwrap(), Error::InvalidPublicKey);
     let key = from_hex("0abcdefgh");
-    assert_eq!(key.err().unwrap(),Error::InvalidHex);
+    assert_eq!(key.err().unwrap(), Error::InvalidHex);
     let key = from_hex("9384526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07");
-    assert_eq!(key.err().unwrap(),Error::InvalidPublicKey);
+    assert_eq!(key.err().unwrap(), Error::InvalidPublicKey);
     let key = from_hex("04fe53c78e36b86aae8082484a4007b706d5678cabb92d178fc95020d4d8dc41ef44cfbb8dfa7a593c7910a5b6f94d079061a7766cbeed73e24ee4f654f1e51904");
     assert!(key.is_ok());
 }
 
 #[test]
 fn add_public_keys() {
-    let p1 = from_hex("0241cc121c419921942add6db6482fb36243faf83317c866d2a28d8c6d7089f7ba").unwrap();
-    let p2 = from_hex("02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443").unwrap();
-    let exp_sum = from_hex("0384526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07").unwrap();
+    let p1 =
+        from_hex("0241cc121c419921942add6db6482fb36243faf83317c866d2a28d8c6d7089f7ba").unwrap();
+    let p2 =
+        from_hex("02e6642fd69bd211f93f7f1f36ca51a26a5290eb2dd1b0d8279a87bb0d480c8443").unwrap();
+    let exp_sum =
+        from_hex("0384526253c27c7aef56c7b71a5cd25bebb66dddda437826defc5b2568bde81f07").unwrap();
     let sum = p1 + p2;
     assert_eq!(p2 + p1, sum);
     assert_eq!(sum, exp_sum);
@@ -96,9 +99,8 @@ fn scalar_multiplication_is_addition() {
 pub fn from_hex(h: &str) -> Result<PublicKey, Error> {
     let data = hex::decode(h).or(Err(Error::InvalidHex))?;
     match data.len() {
-        33 => PublicKey::parse_compressed(array_ref!(data,0,33)),
-        65 => PublicKey::parse(array_ref!(data,0,65)),
+        33 => PublicKey::parse_compressed(array_ref!(data, 0, 33)),
+        65 => PublicKey::parse(array_ref!(data, 0, 65)),
         _ => Err(Error::InvalidPublicKey),
     }
 }
-

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -3,16 +3,16 @@ extern crate secp256k1;
 extern crate secp256k1_test;
 
 use rand::thread_rng;
+use secp256k1::ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
+use secp256k1::signature::sign;
+use secp256k1::{recover, verify};
+use secp256k1::{Message, PublicKey, RecoveryId, SecretKey, SharedSecret, Signature};
 use secp256k1_test::ecdh::SharedSecret as SecpSharedSecret;
 use secp256k1_test::key;
 use secp256k1_test::{
     Message as SecpMessage, RecoverableSignature as SecpRecoverableSignature,
     RecoveryId as SecpRecoveryId, Secp256k1, Signature as SecpSignature,
 };
-use secp256k1::signature::sign;
-use secp256k1::{Message, PublicKey, SecretKey, Signature, RecoveryId, SharedSecret};
-use secp256k1::{ recover, verify};
-use secp256k1::ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
 
 #[test]
 fn test_verify() {

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -3,9 +3,7 @@ extern crate secp256k1;
 extern crate secp256k1_test;
 
 use rand::thread_rng;
-use secp256k1::ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
-use secp256k1::signature::sign;
-use secp256k1::{recover, verify};
+use secp256k1::ecmult::ECMULT_CONTEXT;
 use secp256k1::{Message, PublicKey, RecoveryId, SecretKey, SharedSecret, Signature};
 use secp256k1_test::ecdh::SharedSecret as SecpSharedSecret;
 use secp256k1_test::key;
@@ -41,7 +39,7 @@ fn test_verify() {
     let ctx_sig = Signature::parse(&signature_a);
 
     secp256k1.verify(&message, &signature, &pubkey).unwrap();
-    assert!(verify(&ctx_message, &ctx_sig, &ctx_pubkey));
+    assert!(Signature::verify(&ctx_message, &ctx_sig, &ctx_pubkey));
     let mut f_ctx_sig = ctx_sig.clone();
     f_ctx_sig.r.set_int(0);
     if f_ctx_sig.r != ctx_sig.r {
@@ -89,7 +87,7 @@ fn test_recover() {
     let ctx_sig = Signature::parse(&signature_a);
 
     // secp256k1.recover(&message, &signature).unwrap();
-    let ctx_pubkey = recover(
+    let ctx_pubkey = Signature::recover(
         &ctx_message,
         &ctx_sig,
         &RecoveryId::parse(rec_id.to_i32() as u8).unwrap(),
@@ -203,13 +201,13 @@ fn test_sign_verify() {
     let seckey = SecretKey::parse(&seckey_a).unwrap();
     let message = Message::parse(&message_arr);
 
-    let (sig, recid) = sign(&message, &seckey).unwrap();
+    let (sig, recid) = Message::sign(&message, &seckey).unwrap();
 
     // Self verify
-    assert!(verify(&message, &sig, &pubkey));
+    assert!(Signature::verify(&message, &sig, &pubkey));
 
     // Self recover
-    let recovered_pubkey = recover(&message, &sig, &recid).unwrap();
+    let recovered_pubkey = Signature::recover(&message, &sig, &recid).unwrap();
     let rpa = recovered_pubkey.serialize();
     let opa = pubkey.serialize();
     let rpr: &[u8] = &rpa;
@@ -247,11 +245,11 @@ fn test_failing_sign_verify() {
     let message_arr = [6u8; 32];
     let message = Message::parse(&message_arr);
 
-    let (sig, recid) = sign(&message, &seckey).unwrap();
+    let (sig, recid) = Message::sign(&message, &seckey).unwrap();
     let tmp: u8 = recid.into();
     assert_eq!(tmp, 1u8);
 
-    let recovered_pubkey = recover(&message, &sig, &recid).unwrap();
+    let recovered_pubkey = Signature::recover(&message, &sig, &recid).unwrap();
     let rpa = recovered_pubkey.serialize();
     let opa = pubkey.serialize();
     let rpr: &[u8] = &rpa;

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -3,14 +3,16 @@ extern crate secp256k1;
 extern crate secp256k1_test;
 
 use rand::thread_rng;
-use secp256k1::curve::*;
-use secp256k1::*;
 use secp256k1_test::ecdh::SharedSecret as SecpSharedSecret;
 use secp256k1_test::key;
 use secp256k1_test::{
     Message as SecpMessage, RecoverableSignature as SecpRecoverableSignature,
     RecoveryId as SecpRecoveryId, Secp256k1, Signature as SecpSignature,
 };
+use secp256k1::signature::sign;
+use secp256k1::{Message, PublicKey, SecretKey, Signature, RecoveryId, SharedSecret};
+use secp256k1::{ recover, verify};
+use secp256k1::ecmult::{ECMULT_CONTEXT, ECMULT_GEN_CONTEXT};
 
 #[test]
 fn test_verify() {


### PR DESCRIPTION
Move all structs and methods to submodules and expose what needs to be exposed.
Root module now only contains imports and exports.